### PR TITLE
Bug Report - TweenAnimationBuilder widget.dart

### DIFF
--- a/lib/screens/tween_animation_builder.dart
+++ b/lib/screens/tween_animation_builder.dart
@@ -41,7 +41,7 @@ class _TweenAnimationBuilderWidgetState
             onPressed: () => Navigator.push(
               context,
               MaterialPageRoute(
-                builder: (context) => CodeScreen(code: Code.richTextCode),
+                builder: (context) => CodeScreen(code: Code.tweenAnimationBuilderWidgetCode),
               ),
             ),
           )


### PR DESCRIPTION
Bug: In the TweenAnimationBuilder demo, when the user clicks in code view mode, it shows the RichText code.

Fix: Changed route to TweenAnimationBuilder code.